### PR TITLE
bugfix: Add `?` operator for silent errors

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -55,8 +55,8 @@ export const _parseImports = (module) => {
         default: null,
         named: token.specifiers.map((spec) => {
           return spec.imported === null
-            ? { name: spec.local.value, as: spec.local.value }
-            : { name: spec.imported.value, as: spec.local.value };
+            ? { name: spec?.local?.value, as: spec?.local?.value }
+            : { name: spec?.imported?.value, as: spec?.local?.value }; // Special import styles and things like node_modules end up throwing a silent error here without the ? operator
         }),
       };
     });


### PR DESCRIPTION
In the event of an incompatible parse due to style, such as `import * as x` statements or the existence of a node_modules folder, the library will throw a silent error in the utils. This is because the value of `spec.imported` is not strictly equivalent to the expected value, but is not an object in which contains the required keys that are being requested of it.

By adding the `?` operator, it at least gives you a stack trace to follow to learn what failed to parse and begin investigating what went wrong.